### PR TITLE
Make SVG conversion sequential instead of parallel

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs')
-const { convertFile } = require('convert-svg-to-png')
+const { createConverter } = require('convert-svg-to-png')
 const tablemark = require('tablemark')
 const { capitalCase } = require('change-case')
 const config = require('./.heartrc.json')
@@ -52,18 +52,24 @@ const buildFileObject = () => {
   })
 }
 
-const writeFiles = (files) => {
-  files.forEach(file => {
-    file.pngs.forEach(png => {
-      convertFile(_srcLink(file.svg), {
-        outputFilePath: _destLink(png.name),
-        width: png.size,
-        height: png.size
-      })
-        .then(d => console.log('Created ' + d))
-        .catch(e => console.error(e))
-    })
-  })
+const writeFiles = async (files) => {
+  const converter = createConverter();
+
+  try {
+    for (const file of files) {
+      for (const png of file.pngs) {
+        await converter.convertFile(_srcLink(file.svg), {
+            outputFilePath: _destLink(png.name),
+            width: png.size,
+            height: png.size,
+          })
+          .then((d) => console.log("Created " + d))
+          .catch((e) => console.error(e));
+      }
+    }
+  } finally {
+    converter.destroy();
+  }
 }
 
 const buildTableOutput = (files) => {


### PR DESCRIPTION
[`convert-svg-to-png`](https://www.npmjs.com/package/convert-svg-to-png) uses `puppeteer`, and each call to `convertFile` created a unique instance of `Converter` - which is their wrapper around `puppeteer` that converts the file and destroys itself. Partly described [here](https://www.npmjs.com/package/convert-svg-to-png#createconverteroptions)

Since the calls are being made in parallel, they're all being sent off at once, causing possible failures and timeouts.

***

This PR does two things, first makes all conversion calls use a single `Converter` instance, so only one instance of `puppeteer` is used.

Second, it calls `convertFile` sequentially, so there is no overloading.

***

> If you would rather not use have `async`/`await` and/or `for...of` usage, I could rewrite it without such syntax.